### PR TITLE
ceph/v8.1: use 8-1 instead of 8.1

### DIFF
--- a/overlay/ceph/v8.1-overlay/application-patch.yaml
+++ b/overlay/ceph/v8.1-overlay/application-patch.yaml
@@ -1,6 +1,6 @@
 - op: replace
   path: /metadata/name
-  value: ceph-8.1
+  value: ceph-8-1
 - op: replace
   path: /spec/description
   value: "Pipeline for Ceph 8.1"

--- a/overlay/ceph/v8.1-overlay/component-patch.yaml
+++ b/overlay/ceph/v8.1-overlay/component-patch.yaml
@@ -1,6 +1,6 @@
 - op: replace
   path: /spec/application
-  value: ceph-8.1 # Must match /metadata/name in application-patch.yaml
+  value: ceph-8-1 # Must match /metadata/name in application-patch.yaml
 - op: replace
   path: /spec/source/git/revision
   value: release-8.1 # Replace with your target branch for all components


### PR DESCRIPTION
periods aren't allowed in app/component names