### PR TITLE
overlay: add v9.0 and base for alloy

### DIFF
--- a/overlay/ceph/base/alloy/alloy-override.yaml
+++ b/overlay/ceph/base/alloy/alloy-override.yaml
@@ -1,0 +1,15 @@
+- op: replace
+  path: /metadata/name
+  value: alloy
+- op: replace
+  path: /spec/componentName
+  value: alloy
+- op: replace
+  path: /spec/containerImage
+  value: quay.io/rhceph-dev/alloy
+- op: replace
+  path: /spec/source/git/url
+  value: https://github.com/ibmstorage/alloy.git
+- op: replace
+  path: /spec/source/git/dockerfileUrl
+  value: "Dockerfile"

--- a/overlay/ceph/base/alloy/kustomization.yaml
+++ b/overlay/ceph/base/alloy/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../base # Path to base component
+
+patches:
+  - path: alloy-override.yaml # Path to override file
+    target:
+      kind: Component

--- a/overlay/ceph/v9.0-overlay/kustomization.yaml
+++ b/overlay/ceph/v9.0-overlay/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ../base/grafana
   - ../base/rhceph
   - ../base/rhceph-container
+  - ../base/alloy
 
 patches:
   - target:


### PR DESCRIPTION
Hi @andrewschoen ,

I would like to add a new component under `RH Ceph 9.0` called `alloy-9-0` and from looking at the past changes I have created this PR. I am not very sure if the changes are right, please guide me here!

Thank you.