### PR TITLE
change rhceph-dev to rhceph-ci

### DIFF
--- a/base/component.yaml
+++ b/base/component.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ceph-tenant
   annotations:
     #if onboarding a new component in a new repo uncomment this line
-    build.appstudio.openshift.io/request: configure-pac
+    #build.appstudio.openshift.io/request: configure-pac
     build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
     git-provider: github
     git-provider-url: https://github.com

--- a/overlay/ceph/base/alloy/alloy-override.yaml
+++ b/overlay/ceph/base/alloy/alloy-override.yaml
@@ -6,7 +6,7 @@
   value: alloy
 - op: replace
   path: /spec/containerImage
-  value: quay.io/rhceph-dev/alloy
+  value: quay.io/rhceph-ci/alloy
 - op: replace
   path: /spec/source/git/url
   value: https://github.com/ibmstorage/alloy.git

--- a/overlay/ceph/base/grafana/grafana-override.yaml
+++ b/overlay/ceph/base/grafana/grafana-override.yaml
@@ -6,7 +6,7 @@
   value: grafana
 - op: replace
   path: /spec/containerImage
-  value: quay.io/rhceph-dev/grafana
+  value: quay.io/rhceph-ci/grafana
 - op: replace
   path: /spec/source/git/url
   value: https://github.com/ibmstorage/grafana-container.git

--- a/overlay/ceph/base/haproxy/haproxy-override.yaml
+++ b/overlay/ceph/base/haproxy/haproxy-override.yaml
@@ -6,7 +6,7 @@
   value: haproxy
 - op: replace
   path: /spec/containerImage
-  value: quay.io/rhceph-dev/haproxy
+  value: quay.io/rhceph-ci/haproxy
 - op: replace
   path: /spec/source/git/url
   value: https://github.com/ibmstorage/haproxy.git

--- a/overlay/ceph/base/keepalived/keepalived-override.yaml
+++ b/overlay/ceph/base/keepalived/keepalived-override.yaml
@@ -6,7 +6,7 @@
   value: keepalived
 - op: replace
   path: /spec/containerImage
-  value: quay.io/rhceph-dev/keepalived
+  value: quay.io/rhceph-ci/keepalived
 - op: replace
   path: /spec/source/git/url
   value: https://github.com/ibmstorage/keepalived.git

--- a/overlay/ceph/base/promtail/promtail-override.yaml
+++ b/overlay/ceph/base/promtail/promtail-override.yaml
@@ -6,7 +6,7 @@
   value: promtail
 - op: replace
   path: /spec/containerImage
-  value: quay.io/rhceph-dev/promtail
+  value: quay.io/rhceph-ci/promtail
 - op: replace
   path: /spec/source/git/url
   value: https://github.com/ibmstorage/promtail.git

--- a/overlay/ceph/base/rhceph-container/rhceph-container-override.yaml
+++ b/overlay/ceph/base/rhceph-container/rhceph-container-override.yaml
@@ -6,7 +6,7 @@
   value: rhceph-container
 - op: replace
   path: /spec/containerImage
-  value: quay.io/rhceph-dev/rhceph
+  value: quay.io/rhceph-ci/rhceph
 - op: replace
   path: /spec/source/git/url
   value: https://github.com/ibmstorage/rhceph-container.git

--- a/overlay/ceph/base/rhceph/rhceph-override.yaml
+++ b/overlay/ceph/base/rhceph/rhceph-override.yaml
@@ -6,7 +6,7 @@
   value: rhceph
 - op: replace
   path: /spec/containerImage
-  value: quay.io/rhceph-dev/rhceph
+  value: quay.io/rhceph-ci/rhceph-rpms
 - op: replace
   path: /spec/source/git/url
   value: https://github.com/ibmstorage/ceph.git

--- a/overlay/ceph/base/snmp-notifier/snmp-notifier-override.yaml
+++ b/overlay/ceph/base/snmp-notifier/snmp-notifier-override.yaml
@@ -6,7 +6,7 @@
   value: snmp-notifier
 - op: replace
   path: /spec/containerImage
-  value: quay.io/rhceph-dev/snmp-notifier
+  value: quay.io/rhceph-ci/snmp-notifier
 - op: replace
   path: /spec/source/git/url
   value: https://github.com/ibmstorage/snmp-notifier-container.git


### PR DESCRIPTION
we're going to use quay.io/rhceph-ci now for containers